### PR TITLE
Fix bug where proper content-type was not sent in.

### DIFF
--- a/lib/Cal/DAV.pm
+++ b/lib/Cal/DAV.pm
@@ -135,7 +135,7 @@ sub save {
         #$self->{_fetched} = 1;
     #}
     my $data = $cal->as_string;
-    my $ret  = $res->put($data);
+    my $ret  = $res->put($data, { 'content-type' => 'text/calendar' } );
 
     if ($ret->is_success) {
          return $self->dav->ok( "put $url (" . length($data) ." bytes)",$url );


### PR DESCRIPTION
More modern calendar servers (particularly Apple's) will throw
403 errors if this is not done on the PUT for event updates.

Mostly an example in case this ever gets fixed upstream.